### PR TITLE
Use index file directory as base instead of $_SERVER['DOCUMENT_ROOT']

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ It doesn’t matter which channel you choose for the messages to be posted to. A
 
 ![](https://cloud.githubusercontent.com/assets/2084481/5192055/5b4c7138-74f4-11e4-9e71-5597f30672fe.png)
 
-## Deploy to Heroku [deploy-to-heroku]
+## Deploy to Heroku
 
 If you set up Archibald the easy way, you can use the Heroku Deploy Button:
 

--- a/api.php
+++ b/api.php
@@ -5,6 +5,7 @@ namespace Archibald;
 use Archibald\Archibald;
 
 require 'vendor/autoload.php';
+define('DOCUMENT_ROOT', dirname(__FILE__));
 
 $archie = new Archibald();
 

--- a/index.php
+++ b/index.php
@@ -3,6 +3,7 @@
 namespace Archibald;
 
 require 'vendor/autoload.php';
+define('DOCUMENT_ROOT', dirname(__FILE__));
 
 $archie = new Archibald();
 

--- a/src/Archibald/Archibald.php
+++ b/src/Archibald/Archibald.php
@@ -31,7 +31,7 @@ class Archibald
 	public function loadConfig()
 	{
 		if ($this->hasConfig()) {
-			$this->configPath = $_SERVER['DOCUMENT_ROOT'] . '/' . $this->configName;
+			$this->configPath = DOCUMENT_ROOT . '/' . $this->configName;
 			require_once($this->configPath);
 			return true;
 		}
@@ -45,7 +45,7 @@ class Archibald
 	 */
 	private function hasConfig()
 	{
-		return file_exists($_SERVER['DOCUMENT_ROOT'] . '/' . $this->configName);
+		return file_exists(DOCUMENT_ROOT . '/' . $this->configName);
 	}
 
 	/**


### PR DESCRIPTION
Use base directory of index file as Root -> `dirname(__FILE__)`

instead of `$_SERVER['DOCUMENT_ROOT']`

Because this server variable set by Apache or Nginx points to a default document root folder (eg `/html` or `/www`) and doesn't work on a subdomain or a virtual host environment.

So if you install archie on a subdomain and not in your severs "main" web root, it won't find the config files. So better use the index.php and/or api.php files as root, then it will work everywhere.

Cheers ;-)
